### PR TITLE
Logging exceptions.

### DIFF
--- a/src/main/java/org/carlspring/maven/orientdb/RunOrientDBMojo.java
+++ b/src/main/java/org/carlspring/maven/orientdb/RunOrientDBMojo.java
@@ -52,7 +52,7 @@ public class RunOrientDBMojo extends StartOrientDBMojo
                 }
                 catch (InterruptedException e)
                 {
-                    e.printStackTrace();
+                    getLog().warn("InterruptedException: doExecute().", e);
                 }
             }
         }

--- a/src/main/java/org/carlspring/maven/orientdb/StopOrientDBMojo.java
+++ b/src/main/java/org/carlspring/maven/orientdb/StopOrientDBMojo.java
@@ -65,7 +65,7 @@ public class StopOrientDBMojo extends AbstractOrientDBMojo
 			{
 				throw new MojoExecutionException("Failed to stop the OrientDB server, no server running!");
 			}
-			getLog().error("OrientDB server was already stopped.");
+			getLog().error("OrientDB server was already stopped.", e);
 			return;
 		}
 		getLog().info("OrientDB has stopped!");


### PR DESCRIPTION
1. Throwable.printStackTrace(...) should not be called.
2. Exception handlers should preserve the original exceptions.
